### PR TITLE
Patch shared 01

### DIFF
--- a/public/wp-config.php
+++ b/public/wp-config.php
@@ -15,6 +15,8 @@ define('WP_CONTENT_URL', WP_HOME . '/wp-content');
 //define('WPMU_PLUGIN_URL', WP_CONTENT_URL . '/mu-plugins');
 define('WP_DEFAULT_THEME', 'theme');
 
+define('FS_METHOD', 'direct'); // never prompt for FTP credentials to install plugins
+
 // define('WP_DEBUG_DISPLAY', FALSE); // Do not display error messages
 
 define('DISALLOW_FILE_EDIT', TRUE); // Disable the Plugin and Theme Editor

--- a/public/wp-config.php
+++ b/public/wp-config.php
@@ -45,6 +45,13 @@ define('NONCE_SALT', $wpParams['NONCE_SALT']);
 
 $table_prefix  = 'wp_';
 
+if (strncmp(gethostname(), 'shared-', 7) === 0) {
+	// bedrock-autoloader symlink fix
+	define('PROJECT_ROOT', dirname(__DIR__, 3));
+	define('WP_PLUGIN_DIR', PROJECT_ROOT . '/public/wp-content/plugins');
+	define('WPMU_PLUGIN_DIR', WWW_DIR . '/wp-content/mu-plugins');
+}
+
 define('WP_DEBUG', !Tracy\Debugger::$productionMode);
 
 require_once WP_DIR . '/wp-settings.php';

--- a/public/wp-content/mu-plugins/bedrock-autoloader.php
+++ b/public/wp-content/mu-plugins/bedrock-autoloader.php
@@ -26,7 +26,14 @@ class Autoloader {
     if (isset(self::$_single)) { return; }
 
     self::$_single       = $this; // Singleton set.
-    self::$relative_path = '/../' . basename(__DIR__); // Rel path set.
+
+    /**
+     * @author: Mikulas
+     * This hotfix adds symlink support. Bedrock calls to wp function get_plugins,
+     * which is relative to WP_PLUGIN_DIR. Wp expects plugins and wp-plugins to be
+     * in the same directory, which they are not (even the symlink and mu-plugins are)
+     */
+    self::$relative_path = str_repeat('/..', 100) . WPMU_PLUGIN_DIR;
 
     add_action('plugins_loaded', array($this, 'loadPlugins'), 0); // Always add filter to autoload.
 

--- a/public/wp-content/mu-plugins/bedrock-autoloader.php
+++ b/public/wp-content/mu-plugins/bedrock-autoloader.php
@@ -33,7 +33,11 @@ class Autoloader {
      * which is relative to WP_PLUGIN_DIR. Wp expects plugins and wp-plugins to be
      * in the same directory, which they are not (even the symlink and mu-plugins are)
      */
-    self::$relative_path = str_repeat('/..', 100) . WPMU_PLUGIN_DIR;
+    if (strncmp('/', __DIR__, 1) === 0) {
+      self::$relative_path = str_repeat('/..', 100) . WPMU_PLUGIN_DIR;
+    } else {
+      self::$relative_path = '/../' . basename(__DIR__);
+    }
 
     add_action('plugins_loaded', array($this, 'loadPlugins'), 0); // Always add filter to autoload.
 


### PR DESCRIPTION
- hotfix adds symlink support. Bedrock calls to wp function get_plugins, which is relative to WP_PLUGIN_DIR. Wp expects plugins and wp-plugins to be in the same directory, which they are not (even the symlink and mu-plugins are)
- never prompt for FTP credentials to install plugins