### PR TITLE
admin components with page_roles example

### DIFF
--- a/config/config.neon
+++ b/config/config.neon
@@ -20,6 +20,8 @@ parameters:
 			key:
 			secret:
 			subfolder:
+	pageRoles:
+		- contact
 
 database:
 	dsn: 'mysql:host=%database.host%;dbname=%database.database%'

--- a/mango.json
+++ b/mango.json
@@ -30,7 +30,10 @@
   "dependencies": [
     "bootstrap-styl",
     "jquery",
-    "lt-ie-9"
+    "lt-ie-9",
+    "react",
+    "react-dom",
+    "lodash"
   ],
   "watch": [
     "theme/**/*.{latte,php}"

--- a/theme/admin/addAdminComponent.php
+++ b/theme/admin/addAdminComponent.php
@@ -1,0 +1,69 @@
+<?php
+
+function addAdminComponent($post_type, $title, $name, $data = [], $position = 'side', $priority = 'high', $dataTransformer = NULL) {
+	global $Url;
+	if(!$data) {
+		$data = [];
+	}
+	if(!is_array($post_type)) {
+		$post_type = [ $post_type ];
+	}
+	$id = 'adminComponent'.md5((string) microtime());
+	$fn = function($post) use ($name, $data, $dataTransformer, $id) {
+		$data['post_id'] = $post->ID;
+		if($dataTransformer) {
+			$data = $dataTransformer($post->ID, $data);
+		}
+		$component = [
+			'name' => $name,
+			'data' => $data,
+			'place' => '#' . $id,
+		];
+
+		view('../admin/adminComponentPlaceholder', [
+			'id' => $id,
+			'component' => $component,
+		]);
+	};
+	add_action('add_meta_boxes', function() use ($post_type, $title, $name, $data, $position, $priority, $fn) {
+		foreach($post_type as $cpt) {
+			add_meta_box(
+				(string) microtime(),
+				$title,
+				$fn,
+				$cpt,
+				$position,
+				$priority
+			);
+		}
+	});
+}
+
+function addAdminComponentMeta($post_type, $title, $name, $meta_key, $data = [], $position = 'side', $priority = 'high') {
+	return addAdminComponent($post_type, $title, $name, $data, $position, $priority, function($post_id, $data) use ($meta_key) {
+		$data['meta'] = [
+			'key' => $meta_key,
+			'value' => get_post_meta($post_id, $meta_key, TRUE),
+		];
+		return $data;
+	});
+}
+
+add_action('save_post', function($post_id) {
+	global $Req;
+
+	$meta = $Req->getPost('adminComponentSaveMeta');
+	if($meta) foreach($meta as $key => $val) {
+		update_post_meta($post_id, $key, $val);
+	}
+
+	$meta = $Req->getPost('adminComponentSaveMetaJson');
+	if($meta) foreach($meta as $key => $val) {
+		update_post_meta($post_id, $key, Json::decode($val, Json::FORCE_ARRAY));
+	}
+
+	$callback = $Req->getPost('adminComponentCallback');
+	if($callback) foreach($callback as $key => $val) {
+		call_user_func('adminComponentCallback_'.$key, $post_id, $val);
+	}
+});

--- a/theme/admin/adminComponentPlaceholder.latte
+++ b/theme/admin/adminComponentPlaceholder.latte
@@ -1,0 +1,6 @@
+<div id="{$id}">
+	<div style="text-align: center; margin: 20px">
+		<img src="{=WP_SITEURL}/wp-admin/images/spinner.gif" />
+	</div>
+</div>
+<script>(window.initAdminComponents = window.initAdminComponents || []).push({$component})</script>

--- a/theme/admin/components.php
+++ b/theme/admin/components.php
@@ -1,0 +1,19 @@
+<?php
+
+use Nette\Utils\Json;
+
+require_once __DIR__ . '/addAdminComponent.php';
+
+$roles = get_page_roles_pairs();
+
+if(!empty($roles) && current_user_can('manage_options')) {
+	$props = [ 'roles' => $roles, 'titles' => array_map('get_the_title', $roles), 'nopadding' => TRUE ];
+	addAdminComponent('page', 'Page roles', 'page_roles', $props, 'side', 'high');
+}
+
+function adminComponentCallback_savePageRoles($post_id, $val) {
+	$val = Json::decode($val, Json::FORCE_ARRAY);
+	foreach($val as $key => $post_id) {
+		set_role_page($key, $post_id);
+	}
+}

--- a/theme/scripts/components/PageRolesMetabox.es6
+++ b/theme/scripts/components/PageRolesMetabox.es6
@@ -1,0 +1,70 @@
+import createReactComponent from './createReactComponent'
+import React, { Component } from 'react'
+
+import { map, pickBy, merge } from 'lodash'
+
+class Tr extends Component {
+
+	clearClick = e => {
+		this.props.onChange({ [this.props.name]: null })
+	}
+
+	undoClick = e => {
+		this.props.onChange({ [this.props.name]: false })
+	}
+
+	setThisClick = e => {
+		this.props.onChange({ [this.props.name]: this.props.post_id })
+	}
+
+	render() {
+		const { post_id, page_id, name, originalRoles, title } = this.props
+		return (<tr>
+			<th style={{whiteSpace:"nowrap",fontSize:12}}>
+				{name}
+			</th>
+			{page_id && <td style={{whiteSpace:"nowrap",fontSize:12}}>
+				{(page_id === post_id) ? <strong>this page</strong> : <a href={`?post=${page_id}&action=edit`} title={title}>#{page_id}</a>}
+			</td>}
+			<td style={{textAlign:"right",whiteSpace:"nowrap"}} colSpan={page_id ? 1 : 2}>
+				{!page_id && <button type="button" className="button button-small" onClick={this.setThisClick}>set this page</button>}
+				{page_id && <button type="button" className="button button-small" onClick={this.clearClick}>×</button>}
+				{originalRoles[name] && (page_id !== originalRoles[name]) && (post_id !== originalRoles[name]) && <button type="button" className="button button-small" onClick={this.undoClick}>undo</button>}
+			</td>
+		</tr>)
+	}
+}
+
+class PageRolesMetabox extends Component {
+
+	state = {
+		roles: {}
+	}
+
+	onRowChange = (update) => {
+		this.setState(state => {
+			state.roles = {...state.roles, ...update}
+			state.roles = pickBy(state.roles, val => (val !== false))
+			return state
+		})
+	}
+
+	render() {
+		const roles = {...this.props.roles, ...this.state.roles}
+		const originalRoles = this.props.roles
+		const titles = this.props.titles
+		const post_id = +this.props.post_id
+
+		return <div>
+			<table className="wp-list-table widefat fixed striped posts">
+				<tbody>
+					{map(roles, (page_id, key) => (<Tr key={key} page_id={page_id} post_id={post_id} name={key} originalRoles={originalRoles} onChange={this.onRowChange} title={titles[key]} />))}
+				</tbody>
+			</table>
+			<input type="hidden" name={`adminComponentCallback[savePageRoles]`} value={JSON.stringify(roles)} />
+		</div>
+	}
+
+}
+
+module.exports = createReactComponent(PageRolesMetabox)

--- a/theme/scripts/components/component.es6
+++ b/theme/scripts/components/component.es6
@@ -1,5 +1,5 @@
-var $ = window.jQuery
-var eventSplitter = /^(\S+)\s*(.*)$/
+const $ = window.jQuery
+const eventSplitter = /^(\S+)\s*(.*)$/
 
 /**
  * Abstract component class
@@ -13,7 +13,7 @@ var eventSplitter = /^(\S+)\s*(.*)$/
  *
  * @author Matěj Šimek <email@matejsimek.com> (http://www.matejsimek.com)
  */
-class Component {
+module.exports = class Component {
 
 	/**
 	 * @constructor
@@ -35,14 +35,12 @@ class Component {
 	 * Component listeners
 	 *
 	 * Format:
-	 * 	- "type": "handlerName"
-	 * 	- "type<space>.selector": "handlerName"
-	 *
-	 * @param {Component~eventHandler} event handler which is a component method
+	 *  - "type": "handlerName"
+	 *  - "type<space>.selector": "handlerName"
 	 */
 	get listeners() {
 		return {
-			// 'click .example-child': 'handleClick'
+			// 'click .example-child': 'handleClick',
 		}
 	}
 
@@ -50,34 +48,29 @@ class Component {
 	 * Assign event handlers from this.listeners property
 	 */
 	attachListeners() {
-		let self = this
-		let listeners = this.listeners
+		const listeners = this.listeners
 
-		for(let event in listeners) {
+		for (const event in listeners) {
 			let type = event.trim()
 			let selector = false
-			let callback = this[listeners[event]]
+			const callback = this[listeners[event]]
 
-			let split = event.match(eventSplitter)
-			if(split) {
-				type = split[1]
-				selector = split[2]
+			const split = event.match(eventSplitter)
+			if (split) {
+				[, type, selector] = split
 			}
 
 			/**
-			 * Handler called when an event occured
+			 * Handler called when an event occurred
 			 *
 			 * @callback Component~eventHandler
 			 * @param {object} event - an event object
-			 * @param {Component} self - currrent instance
 			 * @param {Object} data - optional data passed with event
-			 * @this {Element} - an element that catched the event
+			 * @this {Element} - an element that caught the event
 			 */
-			let listener = function(e, data) {
-				callback(e, self, data)
-			}
+			let listener = $.proxy(callback, this)
 
-			if(selector){
+			if (selector) {
 				this.$el.on(type, selector, listener)
 			} else {
 				this.$el.on(type, listener)
@@ -98,22 +91,23 @@ class Component {
 	destroy() {
 		this.detachListeners()
 
-		for (let prop in this) {
+		for (const prop in this) {
 			this[prop] = null
 		}
 	}
 
 	/**
 	 * Returns a child
-	 * @param  {string} CSS selector
+	 * @param  {string} selector - CSS selector
 	 * @return {jQuery|null}
 	 */
 	child(selector) {
-		var result = this.$el.find(selector)
-		if(!result.length) return null
-		else return result.eq(0)
+		const $result = this.$el.find(selector)
+
+		if (!$result.length) {
+			return null
+		}
+		return $result.eq(0)
 	}
 
 }
-
-module.exports = Component

--- a/theme/scripts/components/createReactComponent.es6
+++ b/theme/scripts/components/createReactComponent.es6
@@ -1,0 +1,26 @@
+import React from 'react'
+import DOM from 'react-dom'
+const $ = window.jQuery
+const Component = require('./component')
+
+export default function createReactComponent(Component) {
+	return class ReactComponent extends Component {
+
+		constructor(element, data) {
+			super(element, data)
+
+			if(data.unwrapped) {
+				var $el = $(element)
+				$el.unwrap()
+				$el.unwrap()
+			} else if (data.nopadding) {
+				var $el = $(element)
+				$el.unwrap()
+			}
+
+			DOM.render(<Component {...data} />, element)
+		}
+
+	}
+}
+

--- a/theme/scripts/components/example.es6
+++ b/theme/scripts/components/example.es6
@@ -1,4 +1,4 @@
-var Component = require('./component')
+const Component = require('./component')
 
 /**
  * Example component class
@@ -8,19 +8,21 @@ var Component = require('./component')
  * - DOM event listeners are in Backbone style
  *
  */
-class Example extends Component {
+module.exports = class Example extends Component {
+
+	constructor(el, data) {
+		super(el, data)
+	}
 
 	get listeners() {
 		return {
-			'click .example-child': 'handleClick'
+			'click .example-child': 'handleClick',
 		}
 	}
 
-	handleClick(e, self) {
+	handleClick(e, data) {
 		e.preventDefault()
-		alert(self.data)
+		alert(this.data)
 	}
 
 }
-
-module.exports = Example

--- a/theme/scripts/components/shapes.es6
+++ b/theme/scripts/components/shapes.es6
@@ -1,14 +1,12 @@
-var Component = require('./component')
-var $ = window.jQuery
-
-var spriteInserted = false
+const Component = require('./component')
+const $ = window.jQuery
 
 /**
  * Shapes component class
  *
  * - injects SVG sprite into body
  */
-class Shapes extends Component {
+module.exports = class Shapes extends Component {
 
 	/**
 	 * @param {HTMLElement} element
@@ -17,24 +15,21 @@ class Shapes extends Component {
 	constructor(element, data) {
 		super(element, data)
 
-		this.supportsSVG = document.implementation.hasFeature("http://www.w3.org/TR/SVG11/feature#BasicStructure", "1.1")
-		if(this.supportsSVG && !spriteInserted) this.injectSprite()
+		this.supportsSVG = document.implementation.hasFeature('http://www.w3.org/TR/SVG11/feature#BasicStructure', '1.1')
+
+		if (this.supportsSVG) {
+			this.injectSprite()
+		}
 	}
 
 	injectSprite() {
-		spriteInserted = true
-
 		$.get(this.data.url, (response, status) => {
-			if(status == 'success') {
+			if (status === 'success') {
 				$(document.body).prepend(response)
 			} else {
-				spriteInserted = false
-				this.injectSprite()
+				setTimeout(() => this.injectSprite(), 1000 * 10)
 			}
 		}, 'text')
 	}
 
 }
-
-
-module.exports = Shapes

--- a/theme/scripts/componentsHandler.es6
+++ b/theme/scripts/componentsHandler.es6
@@ -1,0 +1,74 @@
+module.exports = (components, initComponentsPlaceholder = 'initComponents') => {
+	let componentsStartTime, colorLog
+
+	if (DEBUG) {
+		componentsStartTime = performance.now()
+		colorLog = (message, color) => {
+			console.log(`%c${message}`, `color: ${color}`)
+		}
+		colorLog('Initializing components...', 'brown')
+	}
+
+	//
+	// Lazy components initialization from initComponents queue
+	//
+	const instances = []
+
+	// Init function
+	const init = (component) => {
+		let componentStartTime
+
+		if (component.name in components) {
+			if (DEBUG) {
+				componentStartTime = performance.now()
+			}
+
+			const Component = components[component.name] // class
+			const placement = (typeof component.place === 'string') ? document.querySelector(component.place) : component.place // DOM element
+			const instance = new Component(placement, component.data || {}) // new instance
+
+			instances.push(instance)
+
+			if (DEBUG) {
+				const componentEndTime = performance.now()
+				colorLog(`\tcomponent: ${component.name}: ${Math.round(componentEndTime - componentStartTime)}ms`, 'blue')
+			}
+		} else if (DEBUG) {
+			console.warn(`Component with name ${component.name} was not found!`)
+		}
+	}
+	// Instance only required components
+	window[initComponentsPlaceholder].map(init)
+
+	// Allow lazy init of components after page load
+	window[initComponentsPlaceholder] = {
+		push: init,
+	}
+
+	if (DEBUG) {
+		const componentsEndTime = performance.now()
+		colorLog(`Components initialization: ${Math.round(componentsEndTime - componentsStartTime)}ms`, 'blue')
+		colorLog('Instances:', 'brown')
+		console.log(instances)
+	}
+
+	//
+	// Print timing data on page load
+	//
+	if (DEBUG) {
+		const printPerfStats = () => {
+			const timing = window.performance.timing
+			colorLog('Performance:', 'brown')
+			colorLog(
+				`\tdns: \t\t ${timing.domainLookupEnd - timing.domainLookupStart} ms\n` +
+				`\tconnect: \t ${timing.connectEnd - timing.connectStart} ms\n` +
+				`\tttfb: \t\t ${timing.responseStart - timing.connectEnd} ms\n` +
+				`\tbasePage: \t ${timing.responseEnd - timing.responseStart} ms\n` +
+				`\tfrontEnd: \t ${timing.loadEventStart - timing.responseEnd} ms\n`,
+				'blue'
+			)
+		}
+
+		window.addEventListener('load', () => setTimeout(printPerfStats, 1000))
+	}
+}

--- a/theme/scripts/index.es6
+++ b/theme/scripts/index.es6
@@ -1,65 +1,24 @@
-//
-// Main project bundle
-//
+//require('./utils/swRegister')
 
-// Dependencies
-//
-require('./plugins')
+const jQueryFallbackProvider = require('./utils/jQueryFallbackProvider')
+const componentsHandler = require('./componentsHandler')
 
 
-if(DEBUG) console.log('Initializing components...')
-if(DEBUG) console.time('Components initialization')
-
-//
-// Lazy components initialization from initComponents queue
-//
-// Components declarations
-var components = {
-	'example': require('./components/example'),
-	'shapes': require('./components/shapes')
-}
-var instances = []
-
-// Init function
-var init = (component) => {
-	if(component.name in components){
-		if(DEBUG) console.time('\tcomponent: ' + component.name)
-
-		var Component = components[component.name] // class
-		var placement = (typeof component.place == 'string') ? document.querySelector(component.place) : component.place // DOM element
-		var instance = new Component(placement, component.data || {}) // new instance
-
-		instances.push(instance)
-
-		if(DEBUG) console.timeEnd('\tcomponent: ' + component.name)
-	} else {
-		if(DEBUG) console.warn('Component with name ' + component.name + ' was not found!')
-	}
-}
-// Instance only required components
-initComponents.map(init)
-
-// Allow lazy init of components after page load
-initComponents = {
-	push: init
+const onJQueryAvailable = ($) => {
+	require('./plugins')
+	componentsHandler({
+		'example': require('./components/example'),
+		'shapes': require('./components/shapes'),
+	})
 }
 
-if(DEBUG) console.timeEnd('Components initialization')
-if(DEBUG) console.log('Instances', instances)
-
-//
-// Print timing data on page load
-//
-if(DEBUG) {
-	function printPerfStats() {
-		var timing = window.performance.timing
-		console.log('Performance:\n' +
-			'\tdns: \t\t' + (timing.domainLookupEnd - timing.domainLookupStart) + 'ms\n' +
-			'\tconnect: \t' + (timing.connectEnd - timing.connectStart) + 'ms\n' +
-			'\tttfb: \t\t' + (timing.responseStart - timing.connectEnd) + 'ms\n' +
-			'\tbasePage: \t' + (timing.responseEnd - timing.responseStart) + 'ms\n' +
-			'\tfrontEnd: \t' + (timing.loadEventStart - timing.responseEnd) + 'ms\n'
-		)
-	}
-	window.addEventListener('load', () => setTimeout(printPerfStats, 1000))
+const onJQueryMissing = () => {
+	console.log('jQuery dependency is missing. This page might not work correctly. Please try again later.')
 }
+
+
+jQueryFallbackProvider(
+	'/node_modules/jquery/dist/jquery.min.js',
+	onJQueryAvailable,
+	onJQueryMissing
+)

--- a/theme/scripts/plugins.es6
+++ b/theme/scripts/plugins.es6
@@ -1,21 +1,21 @@
-// 
+//
 // Tiny project dependencies like polyfills and environment setup
 //
 
 
 // Avoid `console` errors in browsers that lack a console.
 //
-;(function() {
-	var method
-	var noop = function () {}
-	var methods = [
+(() => {
+	let method
+	const noop = () => {}
+	const methods = [
 		'assert', 'clear', 'count', 'debug', 'dir', 'dirxml', 'error',
 		'exception', 'group', 'groupCollapsed', 'groupEnd', 'info', 'log',
 		'markTimeline', 'profile', 'profileEnd', 'table', 'time', 'timeEnd',
-		'timeStamp', 'trace', 'warn'
+		'timeStamp', 'trace', 'warn',
 	]
-	var length = methods.length
-	var console = (window.console = window.console || {})
+	let length = methods.length
+	const console = (window.console = window.console || {})
 
 	while (length--) {
 		method = methods[length]
@@ -24,4 +24,4 @@
 			console[method] = noop
 		}
 	}
-})();
+})()

--- a/theme/scripts/utils/inject.es6
+++ b/theme/scripts/utils/inject.es6
@@ -1,39 +1,43 @@
-var head = document.head || document.getElementsByTagName('head')[0]
+const head = document.head || document.getElementsByTagName('head')[0]
 
 /**
  * Injects script into the current page
  *
- * @param  {string|Object}  scripts src or Object script attributes with optional 'content' as inline javascript
- * @param  {Function}       load callback
- * 
+ * @param  {string|Object} options      the script's src or Object script attributes with optional 'content' as inline javascript
+ * @param  {Function} successCallback   success callback
+ * @param  {Function} failCallback      failed callback
+ *
  * @author Matěj Šimek <email@matejsimek.com> (http://www.matejsimek.com)
  */
-module.exports = function inject(options, callback) {
-	var script = document.createElement('script')
+module.exports = (options, successCallback, failCallback) => {
+	const script = document.createElement('script')
 
-	script.addEventListener('load', callback)
+	script.addEventListener('load', successCallback)
+	script.addEventListener('error', failCallback)
 	script.type = 'text/javascript'
 
 	// options is an URL string
-	if(typeof options == 'string') {
+	if (typeof options === 'string') {
 		script.src = options
 		script.async = true
 	}
 
 	// options is an object with script attributes
 	// key 'content' is alias for inline script content
-	else if(typeof options == 'object') {
+	else if (typeof options === 'object') {
 
-		for(key in options) {
-			if(!options.hasOwnProperty(key)) continue
-			var value = options[key]
+		for (const key in options) {
+			if (!options.hasOwnProperty(key)) {
+				continue
+			}
+			const value = options[key]
 
-			if(key == 'content') {
+			if (key === 'content') {
 				script.appendChild(document.createTextNode(value))
 			} else {
 				script[key] = value
 			}
-		})
+		}
 
 	}
 

--- a/theme/scripts/utils/jQueryFallbackProvider.es6
+++ b/theme/scripts/utils/jQueryFallbackProvider.es6
@@ -1,0 +1,27 @@
+const inject = require('./inject')
+
+
+module.exports = (fallbackUrl, resolveCallback, rejectCallback) => {
+
+	// jQuery is defined
+	if (window.jQuery) {
+		resolveCallback(window.jQuery)
+		return
+	}
+
+	// jQuery is undefined and without fallback
+	if (!fallbackUrl) {
+		rejectCallback()
+		return
+	}
+
+	//jQuery is undefined with fallback available
+	inject(
+		fallbackUrl,
+		() => {
+			resolveCallback(window.jQuery)
+		},
+		rejectCallback
+	)
+
+}

--- a/theme/scripts/utils/swRegister.es6
+++ b/theme/scripts/utils/swRegister.es6
@@ -1,0 +1,5 @@
+if ('serviceWorker' in navigator) {
+	navigator.serviceWorker.register('serviceWorker.js').then((registration) => {
+		console.log(registration)
+	})
+}

--- a/theme/scripts/wp-admin.es6
+++ b/theme/scripts/wp-admin.es6
@@ -1,3 +1,7 @@
-//
-// Admin section bundle
-//
+const componentsHandler = require('./componentsHandler')
+
+require('./plugins')
+componentsHandler({
+	'example': require('./components/example'),
+	'page_roles': require('./components/PageRolesMetabox'),
+}, 'initAdminComponents')

--- a/theme/utils/page_roles.php
+++ b/theme/utils/page_roles.php
@@ -1,0 +1,27 @@
+<?php
+
+function set_role_page($key, $id) {
+	update_option("role_page_" . $key, $id);
+}
+
+function get_role_page($key) {
+	$id = get_option("role_page_" . $key, NULL);
+	if(!$id) {
+		return NULL;
+	}
+	return icl_object_id($id, 'page', FALSE);
+}
+
+function get_page_roles_pairs() {
+	global $App;
+
+	$pageRoles = $App->parameters['pageRoles'] ?? [];
+
+	$roles = [];
+
+	foreach($pageRoles as $role) {
+		$roles[$role] = get_role_page($role);
+	}
+
+	return $roles;
+}


### PR DESCRIPTION
- [x] aktualizovány skripty z `mango-cli-example`
- [x] implementovaná věc `addAdminComponent`, která přidává custom metaboxy s javascriptovým frontendem
- [x] `role_pages` - nastavování rolí pro stránky, aby se na ně dalo odkazovat z šablon a tak.
- [x] example admin komponenta pro nastavování `role_pages` (`PageRolesMetabox.es6`)
- [ ] vyřešit `PageRolesMetabox` chování u nově založené stránky.
- [ ] napsat to do wiki