### PR TITLE
get_setting - optional second argument

### DIFF
--- a/theme/utils/get_setting.php
+++ b/theme/utils/get_setting.php
@@ -1,6 +1,20 @@
 <?php
 
-function get_setting($group, $field, $lang = NULL) {
+use Nette\Utils\Strings;
+
+function clear_postfix($str, $postfix)
+{
+	if (Strings::endsWith($str, $postfix)) {
+		$len = Strings::length($str) - Strings::length($postfix);
+
+		return Strings::substring($str, 0, $len);
+	}
+
+	return $str;
+}
+
+function get_setting($group, $field = null, $lang = null)
+{
 	static $settings;
 	if (!$settings) {
 		$settings = [];
@@ -13,5 +27,17 @@ function get_setting($group, $field, $lang = NULL) {
 	}
 
 	$postfix = str_replace('{lang}', $lang, $settings[$group]['postfix-format'] ?? '');
-	return $settings[$group][$field . $postfix] ?? $settings[$group][$field] ?? NULL;
+
+	if (!$field) {
+		$group = $settings[$group];
+		$result = [];
+
+		foreach ($group as $key => $val) {
+			$result[clear_postfix($key, $postfix)] = $val;
+		}
+
+		return $result;
+	}
+
+	return $settings[$group][$field.$postfix] ?? $settings[$group][$field] ?? null;
 }

--- a/theme/utils/neon2wp.php
+++ b/theme/utils/neon2wp.php
@@ -49,9 +49,6 @@ function languageMetaFieldsPostfix($data) {
 	$postfix = getLanguagePostfix();
 	$postfixedData = [];
 	foreach ($data as $key => $value) {
-		if (isset($value['fields'])) {
-			$value['fields'] = languageMetaFieldsPostfix($value['fields']);
-		}
 		$id = $key . $postfix;
 		$postfixedData[$id] = $value;
 		$postfixedData[$id]['id'] = $id;


### PR DESCRIPTION
Ted byly povinny 2 argumenty `get_setting(group, field)` - tohle to predelava, aby druhej argument byl nepovinnej a v te situaci vracel celou groupu jako normalni pole (replikoval chovani `get_option`) - tak ze projde vsechny klice v te groupe a odebira ten postfix.

Druha vec - uz nenastavuje lokalizacni postfix pro zanorene groupy a repeatery.