### PR TITLE
Properly detect HTTP_X_FORWARDED_PROTO

### DIFF
--- a/public/init.php
+++ b/public/init.php
@@ -15,6 +15,12 @@ define('CONFIG_DIR', BASE_DIR . '/config');
 
 define('WP_DIR', WWW_DIR . '/wp-core');
 
+// Properly detect HTTPS behind proxy
+if($_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
+	$_SERVER['HTTPS'] = 'on';
+	$_SERVER['SERVER_PORT'] = 443;
+}
+
 // require Composer autoloader
 if(file_exists(LIBS_DIR . '/autoload.php')) {
 	require LIBS_DIR . '/autoload.php';

--- a/public/init.php
+++ b/public/init.php
@@ -16,7 +16,7 @@ define('CONFIG_DIR', BASE_DIR . '/config');
 define('WP_DIR', WWW_DIR . '/wp-core');
 
 // Properly detect HTTPS behind proxy
-if($_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
+if(($_SERVER['HTTP_X_FORWARDED_PROTO'] ?? NULL) === 'https') {
 	$_SERVER['HTTPS'] = 'on';
 	$_SERVER['SERVER_PORT'] = 443;
 }


### PR DESCRIPTION
This change make it works under certain hosting providers (webfaction), which uses HTTP_X_FORWARDED_PROTO header

Source: https://feliciano.tech/blog/running-wordpress-behind-an-sslhttps-terminating-proxy/