### PR TITLE
PageRoles edge cases with drafts and deleted pages

### DIFF
--- a/theme/admin/utils/page-roles.php
+++ b/theme/admin/utils/page-roles.php
@@ -1,24 +1,65 @@
 <?php
 
+function isPostPublished($id) {
+	if(empty($id)) {
+		return null;
+	}
+	return get_post_status($id) === 'publish';
+}
+
+function getPageRolesConfigPath()
+{
+	return get_template_directory().'/schema/page-roles.neon';
+}
+
+
+function getPageRolesOptionKey($lang = null)
+{
+	$lang = $lang ?: get_active_lang_code();
+	return 'page_roles'.$lang;
+}
+
+
+function parsePageRolesConfig($path)
+{
+	return Nette\Neon\Neon::decode(file_get_contents($path));
+}
+
+
 function hasPageRoles()
 {
-	if(file_exists(get_template_directory().'/schema/page-roles.neon')) {
-		$registered = Nette\Neon\Neon::decode(file_get_contents(get_template_directory().'/schema/page-roles.neon'))['register'] ?? [];
+	if(file_exists(getPageRolesConfigPath())) {
+		$registered = Nette\Neon\Neon::decode(file_get_contents(getPageRolesConfigPath()))['register'] ?? [];
 		return !!count($registered);
 	}
 	return false;
 }
 
+
 function pageRolesMetaboxPayload($post_id)
 {
-	$savedRoles = (array) get_option('page_roles'.get_active_lang_code(), []);
-	$registered = Nette\Neon\Neon::decode(file_get_contents(get_template_directory().'/schema/page-roles.neon'))['register'] ?? [];
+	$savedRoles = (array) get_option(getPageRolesOptionKey(), []);
+	$registered = parsePageRolesConfig(getPageRolesConfigPath())['register'] ?? [];
 
 	$roles = array_merge(array_map(function () { return null; }, $registered), $savedRoles);
 	$titles = [];
 
 	foreach ($savedRoles as $id) {
-		$titles[$id] = get_the_title($id);
+		if(!empty($id)) {
+			$append = '';
+			$published = isPostPublished($id);
+
+			if($published === false) {
+				$status = get_post_status($id);
+				if (empty($status)) {
+					$append = ' (deleted)';
+				} else {
+					$append = ' ('.$status.')';
+				}
+			}
+
+			$titles[$id] = get_the_title($id) . $append;
+		}
 	}
 
 	return [
@@ -29,14 +70,21 @@ function pageRolesMetaboxPayload($post_id)
 	];
 }
 
+
+function getPageByRole($role, $allowRaw = false)
+{
+	$savedRoles = (array) get_option(getPageRolesOptionKey(), []);
+
+	if ($allowRaw) {
+		return $savedRoles[$role] ?? null;
+	}
+
+	$id = $savedRoles[$role] ?? null;
+	return isPostPublished($id) ? $id : null;
+}
+
+// Callback after post is saved
 function ac_savePageRoles($post_id, $vals)
 {
 	update_option('page_roles'.get_active_lang_code(), (array) $vals);
-}
-
-function getPageByRole($role)
-{
-	$savedRoles = (array) get_option('page_roles'.get_active_lang_code(), []);
-
-	return $savedRoles[$role] ?? null;
 }


### PR DESCRIPTION
- `getPageByRole` returns `NULL` if not-published (or not-existing) page is selected.
- admin UI shows the information about publish status of pages that are selected in page roles