### PR TITLE
dump and die utils

### DIFF
--- a/config/utils/dumps.php
+++ b/config/utils/dumps.php
@@ -1,0 +1,13 @@
+<?php
+
+// dump and die
+function dd() {
+	call_user_func_array('dump', func_get_args());
+	die();
+}
+
+// bar dump and die
+function bdd() {
+	call_user_func_array('bdump', func_get_args());
+	die();
+}


### PR DESCRIPTION
Are you tired of writing `dump($foobar); die();`. Yes? Your life is now much more effective with `dd($foobar);` shortcut, and respective `bdd` as `bdump and die. Thanks to @JirkaVebr