### PR TITLE
Fix when metabox hides for posts when it is also used in admin_pages

### DIFF
--- a/config/utils/lib/neon-schema.php
+++ b/config/utils/lib/neon-schema.php
@@ -888,11 +888,14 @@ class MetaFieldsNeonDef extends NeonDef
 							'std' => getLanguagePostfixFormat(),
 						];
 					}
-
+					$adminMetabox['id'] = 'admin_' . $adminMetabox['id'];
 					$meta_boxes[] = $adminMetabox;
-				} else {
-					$meta_boxes[] = $metabox;
 				}
+
+				unset($metabox['settings_pages']);
+				unset($metabox['admin_pages']);
+				$meta_boxes[] = $metabox;
+
 			}
 
 			return $meta_boxes;


### PR DESCRIPTION
There was a minor bug when metabox is defined both for `admin_pages` and other things like `post_types` - so then the metabox would work only for admin pages and won't show for those others.