### PR TITLE
add metabox seamless support

### DIFF
--- a/theme/schema/meta-fields.neon
+++ b/theme/schema/meta-fields.neon
@@ -44,6 +44,7 @@ register:
 		title: React / custom data
 		isExample: true
 		context: side
+		seamless: true
 		post_type: page
 		# defined in theme/scripts/wp-admin.ts
 		component: example_metabox

--- a/theme/styles/wp-admin/metabox.sass
+++ b/theme/styles/wp-admin/metabox.sass
@@ -70,3 +70,12 @@
 
 	&.view-mini input
 		width: 5em
+
+#poststuff .rwmb-seamless > .inside
+	margin: 0
+
+.postbox h2
+	font-size: 14px
+	padding: 8px 12px
+	margin: 0
+	line-height: 1.4


### PR DESCRIPTION
You may register metaboxes with `seamless: true` or `style: seamless`, and it will not render the white card around your fields.

Also some code formatting.