### PR TITLE
Pr/event bubbling

### DIFF
--- a/theme/scripts/types.d.ts
+++ b/theme/scripts/types.d.ts
@@ -1,8 +1,21 @@
-type DelegateEvent<E extends keyof HTMLElementEventMap> = HTMLElementEventMap[E] & {
+type NonBubblingEventType =
+	| 'abort'
+	| 'blur'
+	| 'error'
+	| 'focus'
+	| 'load'
+	| 'loadend'
+	| 'loadstart'
+	| 'progress'
+	| 'scroll'
+
+type BubblingEventType = Exclude<keyof HTMLElementEventMap, NonBubblingEventType>
+
+type DelegateEvent<E extends BubblingEventType> = HTMLElementEventMap[E] & {
 	delegateTarget: HTMLElement
 }
 
-type DelegateEventListenerSpec<E extends keyof HTMLElementEventMap> = [
+type DelegateEventListenerSpec<E extends BubblingEventType> = [
 	E,
 	string,
 	(event: DelegateEvent<E>) => void
@@ -14,9 +27,8 @@ type EventListenerSpec<E extends keyof HTMLElementEventMap> = [
 ]
 
 type EventListeners = Array<
-	{
-		[E in keyof HTMLElementEventMap]: DelegateEventListenerSpec<E> | EventListenerSpec<E>
-	}[keyof HTMLElementEventMap]
+	| { [E in keyof HTMLElementEventMap]: EventListenerSpec<E> }[keyof HTMLElementEventMap]
+	| { [E in BubblingEventType]: DelegateEventListenerSpec<E> }[BubblingEventType]
 >
 
 type Constructor<T> = new (...args: any[]) => T

--- a/theme/scripts/types.d.ts
+++ b/theme/scripts/types.d.ts
@@ -20,3 +20,7 @@ type EventListeners = Array<
 >
 
 type Constructor<T> = new (...args: any[]) => T
+
+interface Element {
+	msMatchesSelector(selectors: string): boolean
+}

--- a/theme/scripts/types.d.ts
+++ b/theme/scripts/types.d.ts
@@ -24,3 +24,8 @@ type Constructor<T> = new (...args: any[]) => T
 interface Element {
 	msMatchesSelector(selectors: string): boolean
 }
+
+interface HTMLElementEventMap {
+	focusin: FocusEvent
+	focusout: FocusEvent
+}


### PR DESCRIPTION
Makes it illegal on the type level to attempt to attach delegate handlers of events that don't actually bubble. Furthermore, it addresses the BC-breaking removal of `msMatchesSelector` in [`3.1`](https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#typescript-31). Lastly, it adds some of the DOM-3 events of interest, that haven't yet been introduced to TSJS-lib-generator (see Microsoft/TSJS-lib-generator#333) nor DefinitelyTyped.
