### PR TITLE
tweaks

### DIFF
--- a/theme/utils/imageUrl.php
+++ b/theme/utils/imageUrl.php
@@ -1,0 +1,16 @@
+<?php
+
+function imageUrl($id, $size = 'full')
+{
+	if (is_numeric($id)) {
+		$post = lazy_post($id);
+		if (!$post) {
+			return null;
+		}
+
+		return wp_get_attachment_image_src($post->ID, $size)[0] ?? '';
+	}
+
+	// probably is direct url
+	return $id;
+}

--- a/theme/utils/templating.php
+++ b/theme/utils/templating.php
@@ -1,13 +1,5 @@
 <?php
 
-function translateString($str, $default = null)
-{
-	if (function_exists('icl_register_string') && function_exists('icl_translate')) {
-		icl_register_string('theme-mango', $str, $default ?: $str);
-		return icl_translate('theme-mango', $str, $default ?: $str);
-	}
-
-	return $default ?: $str;
-}
-
-MangoFilters::$set['translate'] = 'translateString';
+MangoFilters::$set['foo'] = function () {
+	return "bar";
+};

--- a/theme/utils/wpml.php
+++ b/theme/utils/wpml.php
@@ -1,0 +1,15 @@
+<?php
+
+function WPML_active()
+{
+	return function_exists('icl_get_languages');
+}
+
+function WPML_get_languages()
+{
+	return icl_get_languages('skip_missing=0');
+}
+
+MangoFilters::$set['translate'] = function ($string, $default = null, $domain = 'theme') {
+	return __($string, $domain);
+};


### PR DESCRIPTION
`imageUrl` function which is ok by taking in either raw url and returning it back... or getting ID of wordpress image and returing its size (from the second argument) url.

`imageUrl('http//picsum.photos/400', 'xxl') => 'http//picsum.photos/400'`

`imageUrl(123, 'xxl') => 'http//url-to-snappyimg/path-to-xxl-size-of-image-123.jpg`

and some WPML helpers