### PR TITLE
fix setup-smtp working by default

### DIFF
--- a/config/config.local.sample.neon
+++ b/config/config.local.sample.neon
@@ -36,8 +36,9 @@ parameters:
 		salt: "20030cf6ef8fc43168d77a7c05f4cd31"
 		projectId: # change this to name of this project
 
-mail:
-	host: smtp.mailgun.org
-	secure: tls
-	username: info@example.com
-	password:
+	smtp:
+		host: smtp.mailtrap.io
+		secure: tls
+		username:
+		password:
+		port: 2525

--- a/config/config.neon
+++ b/config/config.neon
@@ -18,6 +18,13 @@ parameters:
 		dsn: null
 		format: $Format:%h$
 
+	smtp:
+		host: smtp.mailtrap.io
+		secure: tls
+		username:
+		password:
+		port: 2525
+
 database:
 	dsn: 'mysql:host=%database.host%;dbname=%database.database%'
 	user: %database.username%
@@ -28,3 +35,11 @@ database:
 services:
 	db: @database.default.context
 	cache: Nette\Caching\Cache
+
+mail:
+	smtp: true
+	host: %smtp.host%
+	secure: %smtp.secure%
+	username: %smtp.username%
+	password: %smtp.password%
+	port: %smtp.port%


### PR DESCRIPTION
unified smtp config for nette mailer and phpmailer used by wordpress