### PR TITLE
fix api requests with GET params

### DIFF
--- a/config/utils/api-handler.php
+++ b/config/utils/api-handler.php
@@ -20,7 +20,7 @@ $initTheme[] = function ($dir) {
 				$Payload = new Nette\Utils\ArrayHash;
 			}
 
-			$path = $Req->getUrl()->getRelativeUrl();
+			$path = $Req->getUrl()->getPath();
 			$parts = explode('/', trim($path, '/'));
 			if ($parts[0] === 'api') {
 				array_shift($parts);


### PR DESCRIPTION
It didnt recognize correctly api urls with get parameters `?foo=bar`.