### PR TITLE
getMenuTree provides current item param

### DIFF
--- a/config/utils/getMenuTree.php
+++ b/config/utils/getMenuTree.php
@@ -25,5 +25,6 @@ function getMenuTree($location)
 {
 	$menuLocations = get_nav_menu_locations();
 	$items = wp_get_nav_menu_items($menuLocations[$location]) ?: [];
+	_wp_menu_item_classes_by_context($items);
 	return buildMenuTree($items, 0);
 }


### PR DESCRIPTION
Previously returned tree structure of `Post` elements didnt include information about which item is current. After this you get this useful boolean prop `$item->current`.